### PR TITLE
Show item details

### DIFF
--- a/client/src/sections/Fridge/ItemList/AddItemModal/AddItemModal.tsx
+++ b/client/src/sections/Fridge/ItemList/AddItemModal/AddItemModal.tsx
@@ -25,7 +25,7 @@ export default function AddItemModal() {
 
     dispatch(addItem(newItem));
     toggleShowModal();
-  }, [value, toggleShowModal]);
+  }, [dispatch, value, toggleShowModal]);
 
   const handleTextChange = useCallback((newValue) => {
     setValue(newValue);

--- a/client/src/sections/Fridge/ItemList/Item/Item.tsx
+++ b/client/src/sections/Fridge/ItemList/Item/Item.tsx
@@ -1,6 +1,6 @@
 import React, {useCallback} from 'react';
 import {useDispatch} from 'react-redux';
-import {Card, ComplexAction} from '@shopify/polaris';
+import {Card} from '@shopify/polaris';
 import {deleteItem} from 'store/item/actions';
 import {Item as ItemType} from 'store/item/types';
 
@@ -9,34 +9,47 @@ import notFound from 'icons/not-found.svg';
 import './Item.css';
 interface Props {
   item: ItemType;
+  showDetails: boolean;
+  onShowDetails: (item: ItemType) => void;
+  onHideDetails: () => void;
 }
 
-export default function Item({item: {name, icon}}: Props) {
+export default function Item({
+  item,
+  showDetails,
+  onShowDetails,
+  onHideDetails
+}: Props) {
   const dispatch = useDispatch();
+  const {name, icon} = item;
+
+  const handleShowDetails = useCallback(() =>
+    onShowDetails(item), [item, onShowDetails]
+  );
 
   const handleDelete = useCallback(() => {
-    dispatch(deleteItem(name));
-  }, [name]);
-
-  const secondaryFooterActions: ComplexAction[] | undefined =
-  [
-    {
-      content: 'Details',
-      onAction: handleDelete
-    },
-    {
-      content: 'Delete',
-      onAction: handleDelete,
-      destructive: true
+    if (showDetails) {
+      onHideDetails();
     }
-  ];
+    dispatch(deleteItem(name));
+  }, [dispatch, name, showDetails, onHideDetails]);
 
   return (
     <div className='item'>
       <Card
         title={name}
         sectioned
-        secondaryFooterActions={secondaryFooterActions}
+        secondaryFooterActions={[
+          {
+            content: 'Details',
+            onAction: () => handleShowDetails()
+          },
+          {
+            content: 'Delete',
+            onAction: handleDelete,
+            destructive: true
+          }
+        ]}
       >
         <div className='item-section'>
           <img className='item-logo' src={icon || notFound} alt='appleLogo' />

--- a/client/src/sections/Fridge/ItemList/ItemList.tsx
+++ b/client/src/sections/Fridge/ItemList/ItemList.tsx
@@ -1,21 +1,37 @@
-import React from 'react';
+import React, {useState, useCallback} from 'react';
 import {useSelector} from 'react-redux';
 import {Card} from '@shopify/polaris';
 import {selectItems} from 'store/item/selectors';
+import {Item as ItemType} from 'store/item/types';
 import {Item, AddItemModal} from './components';
 
 import './ItemList.css';
+import ItemSummary from './ItemSummary';
 
 export default function ItemList() {
   const items = useSelector(selectItems);
+  const [selectedItem, setSelectedItem] = useState<ItemType | null>(null);
+  const isOpen = selectedItem !== null;
+
+  const handleShowItem = useCallback((item) =>
+    setSelectedItem(item)
+  , []);
+
+  const handleHideItem = useCallback(() =>
+    setSelectedItem(null)
+  , []);
 
   const itemListMarkup = items.map((item) => {
     return (
       <div key={item.name}>
-        <Item item={item} />
+        <Item item={item} showDetails={isOpen} onShowDetails={handleShowItem} onHideDetails={handleHideItem} />
       </div>
     );
   });
+
+  const itemSummaryMarkup = selectedItem !== null
+    ? <ItemSummary item={selectedItem} isOpen={isOpen} onClose={handleHideItem} />
+    : null;
 
   return (
     <div className='item-list'>
@@ -25,6 +41,7 @@ export default function ItemList() {
         </Card>
       </div>
       {itemListMarkup}
+      {itemSummaryMarkup}
     </div>
   );
 }

--- a/client/src/sections/Fridge/ItemList/ItemSummary/ItemSummary.tsx
+++ b/client/src/sections/Fridge/ItemList/ItemSummary/ItemSummary.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import {Sheet} from '@shopify/polaris';
+import {ItemSummaryLayout} from './components';
+import {Item} from 'store/item/types';
+
+interface Props {
+  item: Item;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function ItemSummary({item, isOpen, onClose}: Props) {
+  const sheetContentMarkup = isOpen ? (
+    <>
+      <style>
+        {
+          `[data-portal-id] [data-polaris-layer][data-polaris-overlay] + div {pointer-events: none;}
+          body[data-lock-scrolling] {overflow-y: auto;}
+          #ui[data-lock-scrolling-wrapper] {overflow: auto;}`
+        }
+      </style>
+      <ItemSummaryLayout item={item} onClose={onClose} />
+    </>
+  ): null;
+
+  return (
+    <Sheet open={isOpen} onClose={onClose}>
+      {sheetContentMarkup}
+    </Sheet>
+  );
+}

--- a/client/src/sections/Fridge/ItemList/ItemSummary/ItemSummaryLayout/ItemSummaryContent/ItemSummaryContent.css
+++ b/client/src/sections/Fridge/ItemList/ItemSummary/ItemSummaryLayout/ItemSummaryContent/ItemSummaryContent.css
@@ -1,0 +1,6 @@
+.item-summary-content {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 2rem 5rem;
+}

--- a/client/src/sections/Fridge/ItemList/ItemSummary/ItemSummaryLayout/ItemSummaryContent/ItemSummaryContent.tsx
+++ b/client/src/sections/Fridge/ItemList/ItemSummary/ItemSummaryLayout/ItemSummaryContent/ItemSummaryContent.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import {DataTable} from '@shopify/polaris';
+
+import './ItemSummaryContent.css';
+
+interface Props {
+  category: string;
+  count: number;
+  expiry: string;
+}
+
+export default function ItemSummaryContent({
+  category,
+  count,
+  expiry
+}: Props) {
+  const rows = [
+    ['Category', category],
+    ['Count', count],
+    ['Expiry date', expiry]
+  ];
+
+  return (
+    <div className='item-summary-content'>
+      <DataTable
+        columnContentTypes={[
+          'text',
+          'text'
+        ]}
+        headings={[]}
+        rows={rows}
+      />
+    </div>
+  );
+}

--- a/client/src/sections/Fridge/ItemList/ItemSummary/ItemSummaryLayout/ItemSummaryContent/index.ts
+++ b/client/src/sections/Fridge/ItemList/ItemSummary/ItemSummaryLayout/ItemSummaryContent/index.ts
@@ -1,0 +1,3 @@
+import ItemSummaryContent from './ItemSummaryContent';
+
+export default ItemSummaryContent;

--- a/client/src/sections/Fridge/ItemList/ItemSummary/ItemSummaryLayout/ItemSummaryFooter/ItemSummaryFooter.css
+++ b/client/src/sections/Fridge/ItemList/ItemSummary/ItemSummaryLayout/ItemSummaryFooter/ItemSummaryFooter.css
@@ -1,0 +1,8 @@
+.project-summary-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-top: 1px solid #DFE3E8;
+  padding: 2rem 11rem;
+  width: 100%;
+}

--- a/client/src/sections/Fridge/ItemList/ItemSummary/ItemSummaryLayout/ItemSummaryFooter/ItemSummaryFooter.tsx
+++ b/client/src/sections/Fridge/ItemList/ItemSummary/ItemSummaryLayout/ItemSummaryFooter/ItemSummaryFooter.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import {Button} from '@shopify/polaris';
+
+import './ItemSummaryFooter.css';
+
+interface Props {
+  onClose: () => void;
+}
+
+export default function ItemSummaryFooter({onClose}: Props) {
+  return (
+    <div className='project-summary-footer'>
+      <Button onClick={onClose}>Close</Button>
+      <Button primary>
+        Edit
+      </Button>
+    </div>
+  );
+}

--- a/client/src/sections/Fridge/ItemList/ItemSummary/ItemSummaryLayout/ItemSummaryFooter/index.ts
+++ b/client/src/sections/Fridge/ItemList/ItemSummary/ItemSummaryLayout/ItemSummaryFooter/index.ts
@@ -1,0 +1,3 @@
+import ItemSummaryFooter from './ItemSummaryFooter';
+
+export default ItemSummaryFooter;

--- a/client/src/sections/Fridge/ItemList/ItemSummary/ItemSummaryLayout/ItemSummaryLayout.css
+++ b/client/src/sections/Fridge/ItemList/ItemSummary/ItemSummaryLayout/ItemSummaryLayout.css
@@ -1,0 +1,11 @@
+.item-summary-layout {
+  display: flex;
+  height: 100%;
+  flex-direction: column;
+}
+
+.item-summary-heading {
+  border-bottom: 1px solid #DFE3E8;
+  padding: 2rem 3rem;
+  width: 100%;
+}

--- a/client/src/sections/Fridge/ItemList/ItemSummary/ItemSummaryLayout/ItemSummaryLayout.tsx
+++ b/client/src/sections/Fridge/ItemList/ItemSummary/ItemSummaryLayout/ItemSummaryLayout.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import {Heading, Scrollable} from '@shopify/polaris';
+import {Item} from 'store/item/types';
+
+import './ItemSummaryLayout.css';
+import {ItemSummaryContent, ItemSummaryFooter} from './components';
+
+interface Props {
+  item: Item;
+  onClose: () => void;
+}
+
+export default function ItemSummaryLayout({item, onClose}: Props) {
+  const {name} = item;
+
+  return (
+    <div className='item-summary-layout'>
+      <div className='item-summary-heading'>
+        <Heading>{name}</Heading>
+      </div>
+      <Scrollable>
+        <ItemSummaryContent {...item} />
+      </Scrollable>
+      <ItemSummaryFooter onClose={onClose} />
+    </div>
+  );
+}

--- a/client/src/sections/Fridge/ItemList/ItemSummary/ItemSummaryLayout/components.ts
+++ b/client/src/sections/Fridge/ItemList/ItemSummary/ItemSummaryLayout/components.ts
@@ -1,0 +1,2 @@
+export {default as ItemSummaryContent} from './ItemSummaryContent';
+export {default as ItemSummaryFooter} from './ItemSummaryFooter';

--- a/client/src/sections/Fridge/ItemList/ItemSummary/ItemSummaryLayout/index.ts
+++ b/client/src/sections/Fridge/ItemList/ItemSummary/ItemSummaryLayout/index.ts
@@ -1,0 +1,3 @@
+import ItemSummaryLayout from './ItemSummaryLayout';
+
+export default ItemSummaryLayout;

--- a/client/src/sections/Fridge/ItemList/ItemSummary/components.ts
+++ b/client/src/sections/Fridge/ItemList/ItemSummary/components.ts
@@ -1,0 +1,1 @@
+export {default as ItemSummaryLayout} from './ItemSummaryLayout';

--- a/client/src/sections/Fridge/ItemList/ItemSummary/index.ts
+++ b/client/src/sections/Fridge/ItemList/ItemSummary/index.ts
@@ -1,0 +1,3 @@
+import ItemSummary from './ItemSummary';
+
+export default ItemSummary;

--- a/client/src/sections/Fridge/ItemList/components.ts
+++ b/client/src/sections/Fridge/ItemList/components.ts
@@ -1,2 +1,3 @@
 export {default as Item} from './Item';
 export {default as AddItemModal} from './AddItemModal';
+export {default as ItemSummary} from './ItemSummary';


### PR DESCRIPTION
### What problem are you solving in this PR?
Users should be able to see the details of their items.

### Related issues/PRs:
Resolves https://github.com/siddhero97/CS436I-Memofy/issues/30

### How is this accomplished and what led to this approach?

1. Create the footer for `<ItemSummary />` (76f1e30a7640557dba4e9831b8ba7b0165b916c6)
2. Create the content section for `<ItemSummary />` (c056c21f54a54fa3a811c53bf5afb65126f3df1c)
3. Create the layout for `<ItemSummary />` (8f9bef676c33ea44d5e163b861a7263db902fa03)
4. Create `<ItemSummary />` (b95a8d37cbd0183961b19c78ad8f811cfece51a2)
5. Enhance `<ItemList /> with `<ItemSummary />` (f0e8c4c9b6583b203c68375a023e596928a8bbd4)

### What are the risks in this PR?
N/A

### Before-I-merge checklist
- [x] I have [self-tophatted]
